### PR TITLE
Rebuild firmware as a non-blocking state machine with interrupt-drive…

### DIFF
--- a/arduino/main/main.ino
+++ b/arduino/main/main.ino
@@ -116,9 +116,9 @@ struct ModuleConfig {
 };
 
 ModuleConfig moduleConfig[NUM_MODULES] = {
-  {300, 310, 300, 310, 295, 300, 305},
-  {300, 310, 300, 310, 295, 300, 305},
-  {300, 310, 300, 310, 295, 300, 305},
+  {150, 307, 150, 307, 150, 307, 460},
+  {150, 307, 150, 307, 150, 307, 460},
+  {150, 307, 150, 307, 150, 307, 460},
 };
 
 struct FeederConfig {
@@ -645,15 +645,8 @@ void runMachine() {
 
 void handleCommand(const char* json) {
   JsonDocument doc;
-  DeserializationError err = deserializeJson(doc, json);
-  if (err) {
-    Serial.print(F("{\"error\":\"invalid JSON\",\"reason\":\""));
-    Serial.print(err.c_str());
-    Serial.print(F("\",\"length\":"));
-    Serial.print(strlen(json));
-    Serial.print(F(",\"received\":\""));
-    printJsonEscaped(json);
-    Serial.println(F("\"}"));
+  if (deserializeJson(doc, json)) {
+    Serial.println("{\"error\":\"invalid JSON\"}");
     return;
   }
 
@@ -880,10 +873,11 @@ void handleCommand(const char* json) {
 
   // {"readIR": true} — read current IR sensor state for all modules + hopper
   if (doc["readIR"].is<bool>() && doc["readIR"].as<bool>()) {
-    Serial.print(F("{\"status\":\"ok\",\"ir\":["));
+    JsonDocument res;
+    res["status"] = "ok";
+    JsonArray ir = res["ir"].to<JsonArray>();
     for (int m = 1; m <= NUM_MODULES; m++) {
-      if (m > 1) Serial.print(',');
-      Serial.print(digitalRead(irPin(m)) == LOW ? F("true") : F("false"));  // true = card present
+      ir.add(digitalRead(irPin(m)) == LOW);  // true = card present
     }
     res["hopper"] = hopperHasCards();  // true = cards remain in feeder stack
     replyJson(res);

--- a/arduino/main/main.ino
+++ b/arduino/main/main.ino
@@ -1,6 +1,7 @@
 #include <ArduinoJson.h>
 #include <Wire.h>
 #include <Adafruit_PWMServoDriver.h>
+#include <EEPROM.h>
 
 Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 
@@ -10,6 +11,8 @@ Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 //   ch7-9   = Module 2
 //   ch10-12 = Module 3
 //   ch13    = Feeder (360° continuous rotation servo)
+//   ch14    = Scan light (LED 5) — angled holo-detection light, toggled by the
+//             web app for two-frame foil scans
 #define NUM_MODULES 3
 #define MODULE_CHANNEL_OFFSET 4
 #define FEEDER_CHANNEL 13
@@ -20,20 +23,39 @@ Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver();
 #define IR_PIN_MODULE3 4
 #define IR_TIMEOUT_MS  3000  // max ms to wait for a card before aborting
 
-// Module 1 is where every card lands right after feeding, before any routing
-// decision is made — if it sits there this long with no routing command in
-// progress (e.g. the app never sent a bin command), something's stuck.
-#define MODULE1_JAM_TIMEOUT_MS 20000
+// Any module where a card sits at the gate continuously for this long with no
+// routing command in progress (e.g. the app never sent a bin command) is
+// reported as a jam. Only checked while idle (runMachine()).
+#define JAM_TIMEOUT_MS 20000
 
 // Hopper IR sensor — active LOW: pin reads LOW while cards remain in the feeder stack
 #define IR_PIN_HOPPER 5
 
 // Declared here (before any function) because the Arduino builder hoists
 // auto-generated function prototypes to the top of the file, above any type
-// defined later — if FeedResult were declared next to runFeeder() instead,
-// the hoisted `FeedResult runFeeder();` prototype would precede it and fail
-// to compile ("FeedResult does not name a type").
-enum FeedResult { FEED_DETECTED, FEED_TIMEOUT, FEED_EMPTY };
+// defined later — if these enums were declared next to the operation machine
+// instead, the hoisted prototypes would precede them and fail to compile
+// ("OpKind was not declared in this scope").
+enum OpKind { OP_NONE, OP_ROUTE, OP_FEED, OP_TEST, OP_CLEAR };
+
+enum Phase {
+  PH_NONE,
+  PH_FEED_RUN,     // feeder on; exit on module-1 IR edge or duration timeout
+  PH_FEED_SETTLE,  // feeder on for settleDuration (last-card push into module 1)
+  PH_WAIT_SENSOR,  // wait for a card at op.waitModule (IR_TIMEOUT_MS)
+  PH_CARD_ENTER,   // DELAY_CARD_ENTER after the sensor sees the card
+  PH_PADDLE,       // paddle open on op.waitModule (DELAY_PADDLE)
+  PH_PUSH,         // pusher to side on op.waitModule (DELAY_PUSH)
+  PH_NEUTRAL,      // all servos neutral + 200ms
+  PH_HOLD,         // generic timed hold (op.holdMs), then neutral
+  PH_TEST_OPEN,    // open bottoms + paddles (DELAY_PUSH)
+  PH_TEST_LEFT,    // pushers left (DELAY_PUSH)
+  PH_TEST_RIGHT,   // pushers right (DELAY_PUSH)
+  PH_TEST_FEED,    // feeder on (500ms)
+  PH_TEST_LED_ON,  // LED op.ledIndex on (150ms)
+  PH_TEST_LED_OFF, // LED op.ledIndex off (100ms)
+  PH_CLEAR_OPEN,   // all bottoms open (DELAY_PUSH)
+};
 
 int irPin(int module) {
   if (module == 1) return IR_PIN_MODULE1;
@@ -45,15 +67,47 @@ bool hopperHasCards() {
   return digitalRead(IR_PIN_HOPPER) == LOW;
 }
 
-// Returns true when the IR sensor at 'module' detects a card within timeoutMs.
-bool waitForCard(int module, int timeoutMs = IR_TIMEOUT_MS) {
-  unsigned long start = millis();
-  while (digitalRead(irPin(module)) == HIGH) {
-    if (millis() - start > (unsigned long)timeoutMs) return false;
-    delay(5);
-  }
-  return true;
+// ─── Interrupt-driven module-1 card detection ────────────────────────────────
+// The feeder stops the instant the beam is crossed instead of waiting for a
+// poll — this is what lets the motor run continuously (no pulse/pause cycling).
+volatile bool g_m1CardSeen = false;
+
+void onModule1IR() {
+  if (digitalRead(IR_PIN_MODULE1) == LOW) g_m1CardSeen = true;
 }
+
+// ─── Non-blocking operation machine ──────────────────────────────────────────
+// Every mechanical operation (feed, route, test, clear) is a state machine run
+// from loop(), so serial stays responsive mid-operation: {"cancel":true} aborts
+// any phase, jam alerts abort immediately, and new commands while busy get a
+// clean {"error":"busy"} instead of being swallowed by a blocking delay().
+
+struct OpState {
+  OpKind kind;
+  Phase phase;
+  int bin;         // OP_ROUTE target bin (1-7)
+  int waitModule;  // module whose IR sensor we're waiting for
+  bool pushLeft;
+  unsigned long holdMs;
+  int ledIndex;
+  unsigned long phaseStart;
+  unsigned long deadline;  // whole-operation watchdog
+  int replyId;             // command id to echo when the op completes
+  bool hasReplyId;
+};
+
+OpState op;               // zero-initialized → kind = OP_NONE
+bool cancelRequested = false;
+
+// Any module where a card sits at the gate continuously for this long with no
+// routing command in progress (e.g. the app never sent a bin command) is
+// reported as a jam. Only checked while idle — runMachine() services it.
+unsigned long modulePresentSince[NUM_MODULES + 1] = {0, 0, 0, 0};
+bool moduleJamAlerted[NUM_MODULES + 1] = {false, false, false, false};
+
+// New jam alert during an operation sets this flag so the active command
+// aborts to neutral instead of driving servos into a jammed mechanism.
+bool jamAbortRequested = false;
 
 struct ModuleConfig {
   int bottomClosed, bottomOpen;
@@ -70,28 +124,101 @@ ModuleConfig moduleConfig[NUM_MODULES] = {
 struct FeederConfig {
   int speed;          // PWM pulse for forward motion
   int duration;       // overall timeout (ms) — max total time before giving up
-  int pulseDuration;  // ms to run the motor per pulse (0 = continuous feed, no pulsing)
-  int pauseDuration;  // ms to pause between pulses (IR checked after each stop)
+  int pulseDuration;  // kept for config compatibility (0 = continuous feed)
+  int pauseDuration;  // kept for config compatibility
   int settleDuration; // ms to keep feeding after the IR first sees the card, so it
                        // travels all the way into the module 1 mechanism instead of
                        // stopping right at the sensor's beam
 };
 
-FeederConfig feederConfig = {315, 1000, 40, 100, 100};
+FeederConfig feederConfig = {400, 3000, 0, 50, 150};
+
+// ─── Calibration persistence (EEPROM) ───────────────────────────────────────
+// Module/feeder config is persisted so a reboot (e.g. a power blip mid-run)
+// restores the tuned values instead of silently reverting to stock pulses.
+// The magic + version guard detects stale data from older firmware or a
+// hardware change (e.g. servo swap) and falls back to factory defaults.
+#define CONFIG_MAGIC       0x4D56  // "MV"
+#define CONFIG_VERSION     1
+#define CONFIG_EEPROM_ADDR 0
+
+struct PersistedCalibration {
+  uint16_t magic;
+  uint8_t version;
+  ModuleConfig modules[NUM_MODULES];
+  FeederConfig feeder;
+};
+
+// Factory defaults — keep in sync with the moduleConfig/feederConfig
+// initializers above; resetConfig restores these.
+void setFactoryDefaults() {
+  ModuleConfig factoryModules[NUM_MODULES] = {
+    {150, 307, 150, 307, 150, 307, 460},
+    {150, 307, 150, 307, 150, 307, 460},
+    {150, 307, 150, 307, 150, 307, 460},
+  };
+  memcpy(moduleConfig, factoryModules, sizeof(moduleConfig));
+  feederConfig.speed = 400;
+  feederConfig.duration = 3000;
+  feederConfig.pulseDuration = 0;
+  feederConfig.pauseDuration = 50;
+  feederConfig.settleDuration = 150;
+}
+
+void loadCalibration() {
+  PersistedCalibration stored;
+  EEPROM.get(CONFIG_EEPROM_ADDR, stored);
+  if (stored.magic == CONFIG_MAGIC && stored.version == CONFIG_VERSION) {
+    memcpy(moduleConfig, stored.modules, sizeof(moduleConfig));
+    feederConfig = stored.feeder;
+  }
+}
+
+void saveCalibration() {
+  PersistedCalibration data;
+  data.magic = CONFIG_MAGIC;
+  data.version = CONFIG_VERSION;
+  memcpy(data.modules, moduleConfig, sizeof(moduleConfig));
+  data.feeder = feederConfig;
+  EEPROM.put(CONFIG_EEPROM_ADDR, data);
+}
 
 // Routing delays (ms) — tune to match your hardware timing
 #define DELAY_CARD_ENTER   300  // time for card to settle after target bottom opens
 #define DELAY_PADDLE       300  // time for paddle to engage
 #define DELAY_PUSH         600  // time for pusher to complete its stroke
 
-#define MAX_CMD_LEN 200
-char inputBuffer[MAX_CMD_LEN + 1];
-uint8_t inputLen = 0;
-bool inputOverflowed = false;
+// Fixed-size serial line buffer — avoids String heap fragmentation on long
+// sessions. Oversized lines are discarded cleanly.
+#define INPUT_BUFFER_MAX 256
+char inputBuffer[INPUT_BUFFER_MAX + 1];
+int inputBufferLen = 0;
 
-// Idle-time jam watch for module 1 — see checkModule1Jam().
-unsigned long module1PresentSince = 0;
-bool module1JamAlerted = false;
+// Request/response correlation. A command may carry an optional numeric "id";
+// every reply to that command then echoes it, so the web app can match
+// responses to requests even while the firmware emits asynchronous messages
+// (e.g. the jam alert) in between. Messages that are NOT replies to a command
+// (boot "ready", jam alerts) intentionally never carry an id.
+int g_cmdId = 0;
+bool g_hasCmdId = false;
+
+void replyJson(JsonDocument& res) {
+  if (g_hasCmdId) res["id"] = g_cmdId;
+  serializeJson(res, Serial);
+  Serial.println();
+}
+
+void replyLiteral(const char* json) {
+  if (!g_hasCmdId) {
+    Serial.println(json);
+    return;
+  }
+  JsonDocument res;
+  deserializeJson(res, json);
+  res["id"] = g_cmdId;
+  serializeJson(res, Serial);
+  Serial.println();
+}
 
 int getChannel(int module, int servoOffset) {
   return MODULE_CHANNEL_OFFSET + (module - 1) * 3 + servoOffset;
@@ -108,117 +235,39 @@ void setModuleNeutral(int module) {
   setServoPosition(getChannel(module, 2), c.pusherNeutral);
 }
 
+void setAllNeutral() {
+  for (int m = 1; m <= NUM_MODULES; m++) setModuleNeutral(m);
+  stopFeeder();
+}
+
 void stopFeeder() {
   pwm.setPin(FEEDER_CHANNEL, 0);  // cut PWM signal entirely to stop 360° servo
 }
 
-// Stops the feeder once the IR sees the card. Cards still behind it in the
-// hopper push the current one the rest of the way into module 1, so no extra
-// run time is needed. But the last card has nothing behind it to push it in —
-// so if the hopper is now empty, keep the motor running for
-// feederConfig.settleDuration more ms before stopping, to carry it the rest
-// of the way into the mechanism.
-void settleAndStopFeeder() {
-  if (!hopperHasCards()) {
-    delay(feederConfig.settleDuration);
-  }
-  stopFeeder();
-}
-
-// Runs the feeder in short pulses, checking module 1 IR between each stop.
-// Keeps feeding (see settleAndStopFeeder) once a card is detected. Returns
-// FEED_EMPTY only if there was nothing to feed AND no card already waiting
-// at module 1 - once feeding is underway, the hopper going empty is normal
-// (it just means this is the last card) and must NOT abort the feed; only
-// the module 1 sensor or the overall feederConfig.duration timeout should
-// stop it. If pulseDuration is 0, the motor runs continuously (no
-// pulse/pause cycling) while IR is polled throughout.
-//
-// routeCard() calls this again as a presence check right before routing,
-// after the card has already been fed. For the last card in the hopper,
-// hopperHasCards() is false by then even though the card is sitting right
-// at the sensor - so the module 1 check must come before the hopper check,
-// or routeCard() wrongly reports the feeder empty instead of routing the
-// card that's already there.
-FeedResult runFeeder() {
-  unsigned long start = millis();
-
-  if (digitalRead(irPin(1)) == LOW) return FEED_DETECTED;
-
-  if (!hopperHasCards()) return FEED_EMPTY;
-
-  if (feederConfig.pulseDuration <= 0) {
-    setServoPosition(FEEDER_CHANNEL, feederConfig.speed);
-    while (millis() - start < (unsigned long)feederConfig.duration) {
-      if (digitalRead(irPin(1)) == LOW) {
-        settleAndStopFeeder();
-        return FEED_DETECTED;
-      }
-      delay(2);
+// Idle-time jam watch — one entry per module index (1..NUM_MODULES; see
+// checkModuleJams()).
+void checkModuleJams() {
+  for (int m = 1; m <= NUM_MODULES; m++) {
+    bool present = digitalRead(irPin(m)) == LOW;
+    if (!present) {
+      modulePresentSince[m] = 0;
+      moduleJamAlerted[m] = false;
+      continue;
     }
-    stopFeeder();
-    return FEED_TIMEOUT;
-  }
-
-  while (millis() - start < (unsigned long)feederConfig.duration) {
-    // Check before starting the motor — catches cards that arrived during the pause
-    if (digitalRead(irPin(1)) == LOW) return FEED_DETECTED;
-
-    setServoPosition(FEEDER_CHANNEL, feederConfig.speed);
-
-    // Poll IR mid-pulse so we catch the moment the card trips the sensor
-    unsigned long pulseStart = millis();
-    while (millis() - pulseStart < (unsigned long)feederConfig.pulseDuration) {
-      if (digitalRead(irPin(1)) == LOW) {
-        settleAndStopFeeder();
-        return FEED_DETECTED;
-      }
-      delay(2);
+    if (modulePresentSince[m] == 0) {
+      modulePresentSince[m] = millis();
+      continue;
     }
-
-    stopFeeder();
-    if (digitalRead(irPin(1)) == LOW) {
-      // Card arrived during the pause window — motor's already off. Only the
-      // last card (hopper now empty) needs an extra push to fully seat it.
-      if (!hopperHasCards()) {
-        setServoPosition(FEEDER_CHANNEL, feederConfig.speed);
-        delay(feederConfig.settleDuration);
-        stopFeeder();
-      }
-      return FEED_DETECTED;
+    if (!moduleJamAlerted[m] && millis() - modulePresentSince[m] > JAM_TIMEOUT_MS) {
+      moduleJamAlerted[m] = true;
+      jamAbortRequested = true;
+      JsonDocument res;
+      res["error"] = "jam";
+      res["module"] = m;
+      serializeJson(res, Serial);  // async — deliberately no command id
+      Serial.println();
     }
-    delay(feederConfig.pauseDuration);
   }
-  return FEED_TIMEOUT;
-}
-
-// Watches module 1's IR sensor while idle (only runs between commands, since
-// routeCard()/runFeeder() block loop() for their duration). If a card has
-// been sitting there continuously longer than MODULE1_JAM_TIMEOUT_MS — e.g.
-// the app never followed up with a bin command — report it once so it isn't
-// silently left for the operator to discover. Clears itself (and re-arms)
-// as soon as the sensor sees the card leave.
-void checkModule1Jam() {
-  bool present = digitalRead(IR_PIN_MODULE1) == LOW;
-  if (!present) {
-    module1PresentSince = 0;
-    module1JamAlerted = false;
-    return;
-  }
-  if (module1PresentSince == 0) {
-    module1PresentSince = millis();
-    return;
-  }
-  if (!module1JamAlerted && millis() - module1PresentSince > MODULE1_JAM_TIMEOUT_MS) {
-    module1JamAlerted = true;
-    Serial.println(F("{\"error\":\"jam\",\"module\":1}"));
-  }
-}
-
-void setAllNeutral() {
-  for (int m = 1; m <= NUM_MODULES; m++) setModuleNeutral(m);
-  stopFeeder();
-  delay(200);
 }
 
 int getPositionPulse(int module, int servoOffset, const char* position) {
@@ -246,127 +295,355 @@ int getServoOffset(const char* servo) {
   return -1;
 }
 
-// Route a card to the given bin number (1–7).
-//   Bin 1: wait for card at module 1, open paddle, push left
-//   Bin 2: wait for card at module 1, open paddle, push right
-//   Bin 3: wait for card at module 1, open bottom → wait for module 2, push left
-//   Bin 4: wait for card at module 1, open bottom → wait for module 2, push right
-//   Bin 5: wait for m1, open bottom → wait for m2, open bottom → wait for m3, push left
-//   Bin 6: wait for m1, open bottom → wait for m2, open bottom → wait for m3, push right
-//   Bin 7: wait for card at module 1, open all bottoms (catch-all)
-void routeCard(int bin) {
-  if (bin < 1 || bin > 7) {
-    Serial.println(F("{\"error\":\"bin must be 1-7\"}"));
+// ─── Operation machine: start helpers ────────────────────────────────────────
+
+void clearOp() {
+  op.kind = OP_NONE;
+  op.phase = PH_NONE;
+}
+
+void beginOp(OpKind kind, unsigned long budgetMs) {
+  op.kind = kind;
+  op.phase = PH_NONE;
+  op.bin = 0;
+  op.waitModule = 0;
+  op.pushLeft = false;
+  op.holdMs = 0;
+  op.ledIndex = 1;
+  op.deadline = millis() + budgetMs;
+  op.replyId = g_cmdId;
+  op.hasReplyId = g_hasCmdId;
+  cancelRequested = false;
+  jamAbortRequested = false;
+}
+
+// Reply to the command that started the op (not the most recent command — a
+// ping could have arrived mid-operation).
+void replyOpJson(JsonDocument& res) {
+  if (op.hasReplyId) res["id"] = op.replyId;
+  serializeJson(res, Serial);
+  Serial.println();
+}
+
+void finishOpOkRouted() {
+  JsonDocument res;
+  res["status"] = "routed";
+  res["bin"] = op.bin;
+  replyOpJson(res);
+  clearOp();
+}
+
+void finishFeedDetected() {
+  JsonDocument res;
+  res["status"] = "ok";
+  res["detected"] = true;
+  res["empty"] = false;
+  replyOpJson(res);
+  clearOp();
+}
+
+void finishFeedEmpty() {
+  JsonDocument res;
+  res["error"] = "empty: feeder hopper is out of cards";
+  res["empty"] = true;
+  replyOpJson(res);
+  clearOp();
+}
+
+void finishOpError(const char* msg) {
+  JsonDocument res;
+  res["error"] = msg;
+  replyOpJson(res);
+  clearOp();
+}
+
+void finishOpAborted(const char* msg) {
+  JsonDocument res;
+  res["error"] = msg;
+  res["aborted"] = true;
+  replyOpJson(res);
+  clearOp();
+}
+
+void finishTestComplete() {
+  JsonDocument res;
+  res["status"] = "test_complete";
+  replyOpJson(res);
+  clearOp();
+}
+
+void finishCleared() {
+  JsonDocument res;
+  res["status"] = "cleared";
+  replyOpJson(res);
+  clearOp();
+}
+
+// Branch after the card has been fed into module 1 — per-bin routing plan.
+void afterFeedDone() {
+  if (op.kind == OP_FEED) {
+    finishFeedDetected();
     return;
   }
-
-  // Run feeder until module 1 IR detects the card (or timeout/empty hopper)
-  FeedResult feedResult = runFeeder();
-  if (feedResult != FEED_DETECTED) {
-    Serial.print(F("{\"error\":\""));
-    Serial.print(feedResult == FEED_EMPTY
-      ? F("empty: feeder hopper is out of cards")
-      : F("timeout: feeder did not deliver card to module 1"));
-    Serial.print(F("\",\"empty\":"));
-    Serial.print(feedResult == FEED_EMPTY ? F("true") : F("false"));
-    Serial.println(F("}"));
-    setAllNeutral();
-    return;
-  }
-
+  int bin = op.bin;
   if (bin == 7) {
-    // Open all bottoms so card passes through to the catch-all position
+    // Catch-all: open every bottom so the card drops to the catch-all position.
     for (int m = 1; m <= NUM_MODULES; m++) {
       setServoPosition(getChannel(m, 0), moduleConfig[m - 1].bottomOpen);
     }
-    delay(DELAY_PUSH);
-    setAllNeutral();
-    delay(200);
-
-  } else if (bin <= 2) {
-    // Module 1: open paddle, then push
-    ModuleConfig& c = moduleConfig[0];
-    setServoPosition(getChannel(1, 1), c.paddleOpen);
-    delay(DELAY_PADDLE);
-    setServoPosition(getChannel(1, 2), bin == 1 ? c.pusherLeft : c.pusherRight);
-    delay(DELAY_PUSH);
-    setModuleNeutral(1);
-    delay(200);
-
-  } else if (bin <= 4) {
-    // Open module 1 bottom and wait for card to arrive at module 2
-    bool pushLeft = (bin == 3);
-    setServoPosition(getChannel(1, 0), moduleConfig[0].bottomOpen);
-
-    if (!waitForCard(2)) {
-      Serial.println(F("{\"error\":\"timeout: no card detected at module 2\"}"));
-      setAllNeutral();
-      return;
-    }
-    delay(DELAY_CARD_ENTER);
-
-    ModuleConfig& c2 = moduleConfig[1];
-    setServoPosition(getChannel(2, 1), c2.paddleOpen);
-    delay(DELAY_PADDLE);
-    setServoPosition(getChannel(2, 2), pushLeft ? c2.pusherLeft : c2.pusherRight);
-    delay(DELAY_PUSH);
-    setModuleNeutral(1);
-    setModuleNeutral(2);
-    delay(200);
-
+    op.phase = PH_HOLD;
+    op.holdMs = DELAY_PUSH;
+  } else if (bin == 1 || bin == 2) {
+    // Module 1: open paddle, then push.
+    op.pushLeft = (bin == 1);
+    op.waitModule = 1;
+    op.phase = PH_PADDLE;
+    setServoPosition(getChannel(1, 1), moduleConfig[0].paddleOpen);
   } else {
-    // Open module 1 bottom and wait for card at module 2, then open module 2 bottom
-    // and wait for card at module 3
-    bool pushLeft = (bin == 5);
+    // Bins 3-6: open module 1 bottom and await the card at the next module.
+    op.pushLeft = (bin == 3 || bin == 5);
+    op.waitModule = 2;
+    op.phase = PH_WAIT_SENSOR;
     setServoPosition(getChannel(1, 0), moduleConfig[0].bottomOpen);
-
-    if (!waitForCard(2)) {
-      Serial.println(F("{\"error\":\"timeout: no card detected at module 2\"}"));
-      setAllNeutral();
-      return;
-    }
-    setServoPosition(getChannel(2, 0), moduleConfig[1].bottomOpen);
-
-    if (!waitForCard(3)) {
-      Serial.println(F("{\"error\":\"timeout: no card detected at module 3\"}"));
-      setAllNeutral();
-      return;
-    }
-    delay(DELAY_CARD_ENTER);
-
-    ModuleConfig& c3 = moduleConfig[2];
-    setServoPosition(getChannel(3, 1), c3.paddleOpen);
-    delay(DELAY_PADDLE);
-    setServoPosition(getChannel(3, 2), pushLeft ? c3.pusherLeft : c3.pusherRight);
-    delay(DELAY_PUSH);
-    setModuleNeutral(1);
-    setModuleNeutral(2);
-    setModuleNeutral(3);
-    delay(200);
   }
-
-  Serial.print(F("{\"status\":\"routed\",\"bin\":"));
-  Serial.print(bin);
-  Serial.println(F("}"));
+  op.phaseStart = millis();
 }
 
-void printJsonEscaped(const char* s) {
-  for (const char* p = s; *p; p++) {
-    char c = *p;
-    if (c == '"' || c == '\\') {
-      Serial.write('\\');
-      Serial.write(c);
-    } else if (c == '\n') {
-      Serial.print(F("\\n"));
-    } else if (c == '\r') {
-      Serial.print(F("\\r"));
-    } else if ((unsigned char)c >= 0x20) {
-      Serial.write(c);
+void beginRoute(int bin) {
+  beginOp(OP_ROUTE, 20000);
+  op.bin = bin;
+  if (digitalRead(irPin(1)) == LOW) { afterFeedDone(); return; }  // card already there
+  if (!hopperHasCards()) { finishOpError("empty: feeder hopper is out of cards"); return; }
+  g_m1CardSeen = false;
+  op.phase = PH_FEED_RUN;
+  op.phaseStart = millis();
+}
+
+void beginFeed() {
+  beginOp(OP_FEED, 15000);
+  if (digitalRead(irPin(1)) == LOW) { finishFeedDetected(); return; }
+  if (!hopperHasCards()) { finishFeedEmpty(); return; }
+  g_m1CardSeen = false;
+  op.phase = PH_FEED_RUN;
+  op.phaseStart = millis();
+}
+
+void beginTest() {
+  beginOp(OP_TEST, 30000);
+  for (int m = 1; m <= NUM_MODULES; m++) {
+    setServoPosition(getChannel(m, 0), moduleConfig[m - 1].bottomOpen);
+    setServoPosition(getChannel(m, 1), moduleConfig[m - 1].paddleOpen);
+  }
+  op.phase = PH_TEST_OPEN;
+  op.phaseStart = millis();
+}
+
+void beginClear() {
+  beginOp(OP_CLEAR, 10000);
+  for (int m = 1; m <= NUM_MODULES; m++) {
+    setServoPosition(getChannel(m, 0), moduleConfig[m - 1].bottomOpen);
+  }
+  op.phase = PH_CLEAR_OPEN;
+  op.phaseStart = millis();
+}
+
+// ─── Operation machine: run from loop() ──────────────────────────────────────
+void runMachine() {
+  if (op.kind == OP_NONE) {
+    checkModuleJams();
+    return;
+  }
+
+  unsigned long now = millis();
+
+  if (cancelRequested) {
+    cancelRequested = false;
+    setAllNeutral();
+    finishOpAborted("cancelled");
+    return;
+  }
+  if (jamAbortRequested) {
+    jamAbortRequested = false;
+    setAllNeutral();
+    finishOpAborted("aborted: jam detected");
+    return;
+  }
+  if (now > op.deadline) {
+    setAllNeutral();
+    finishOpError("timeout: operation exceeded its budget");
+    return;
+  }
+
+  switch (op.phase) {
+    case PH_FEED_RUN: {
+      // Motor runs continuously; the interrupt flag stops it the moment the
+      // module-1 beam is crossed (no pulse/pause cycling, no polling delay).
+      setServoPosition(FEEDER_CHANNEL, feederConfig.speed);
+      if (g_m1CardSeen) {
+        g_m1CardSeen = false;
+        if (hopperHasCards()) {
+          // Cards behind it push this one the rest of the way — stop now.
+          stopFeeder();
+          afterFeedDone();
+        } else {
+          // Last card: keep pushing for settleDuration so it seats fully.
+          op.phase = PH_FEED_SETTLE;
+          op.phaseStart = now;
+        }
+      } else if (now - op.phaseStart > (unsigned long)feederConfig.duration) {
+        stopFeeder();
+        finishOpError("timeout: feeder did not deliver card to module 1");
+      }
+      break;
     }
+    case PH_FEED_SETTLE: {
+      if (now - op.phaseStart >= (unsigned long)feederConfig.settleDuration) {
+        stopFeeder();
+        afterFeedDone();
+      }
+      break;
+    }
+    case PH_WAIT_SENSOR: {
+      if (digitalRead(irPin(op.waitModule)) == LOW) {
+        if (op.bin >= 5 && op.waitModule == 2) {
+          // Bins 5/6: card at module 2 — open module 2's bottom, await module 3.
+          setServoPosition(getChannel(2, 0), moduleConfig[1].bottomOpen);
+          op.waitModule = 3;
+          op.phaseStart = now;
+        } else {
+          op.phase = PH_CARD_ENTER;
+          op.phaseStart = now;
+        }
+      } else if (now - op.phaseStart > IR_TIMEOUT_MS) {
+        char msg[48];
+        snprintf(msg, sizeof(msg), "timeout: no card detected at module %d", op.waitModule);
+        setAllNeutral();
+        finishOpError(msg);
+      }
+      break;
+    }
+    case PH_CARD_ENTER: {
+      if (now - op.phaseStart >= DELAY_CARD_ENTER) {
+        op.phase = PH_PADDLE;
+        op.phaseStart = now;
+        setServoPosition(
+          getChannel(op.waitModule, 1),
+          moduleConfig[op.waitModule - 1].paddleOpen);
+      }
+      break;
+    }
+    case PH_PADDLE: {
+      if (now - op.phaseStart >= DELAY_PADDLE) {
+        op.phase = PH_PUSH;
+        op.phaseStart = now;
+        setServoPosition(
+          getChannel(op.waitModule, 2),
+          op.pushLeft ? moduleConfig[op.waitModule - 1].pusherLeft
+                      : moduleConfig[op.waitModule - 1].pusherRight);
+      }
+      break;
+    }
+    case PH_PUSH: {
+      if (now - op.phaseStart >= DELAY_PUSH) {
+        op.phase = PH_NEUTRAL;
+        op.phaseStart = now;
+        setAllNeutral();
+      }
+      break;
+    }
+    case PH_NEUTRAL: {
+      if (now - op.phaseStart >= 200) {
+        if (op.kind == OP_ROUTE) finishOpOkRouted();
+        else if (op.kind == OP_TEST) finishTestComplete();
+        else if (op.kind == OP_CLEAR) finishCleared();
+        else finishOpError("internal error");
+      }
+      break;
+    }
+    case PH_HOLD: {
+      if (now - op.phaseStart >= op.holdMs) {
+        op.phase = PH_NEUTRAL;
+        op.phaseStart = now;
+        setAllNeutral();
+      }
+      break;
+    }
+    case PH_TEST_OPEN: {
+      if (now - op.phaseStart >= DELAY_PUSH) {
+        op.phase = PH_TEST_LEFT;
+        op.phaseStart = now;
+        for (int m = 1; m <= NUM_MODULES; m++) {
+          setServoPosition(getChannel(m, 2), moduleConfig[m - 1].pusherLeft);
+        }
+      }
+      break;
+    }
+    case PH_TEST_LEFT: {
+      if (now - op.phaseStart >= DELAY_PUSH) {
+        op.phase = PH_TEST_RIGHT;
+        op.phaseStart = now;
+        for (int m = 1; m <= NUM_MODULES; m++) {
+          setServoPosition(getChannel(m, 2), moduleConfig[m - 1].pusherRight);
+        }
+      }
+      break;
+    }
+    case PH_TEST_RIGHT: {
+      if (now - op.phaseStart >= DELAY_PUSH) {
+        setAllNeutral();
+        op.phase = PH_TEST_FEED;
+        op.phaseStart = now;
+        setServoPosition(FEEDER_CHANNEL, feederConfig.speed);
+      }
+      break;
+    }
+    case PH_TEST_FEED: {
+      if (now - op.phaseStart >= 500) {
+        stopFeeder();
+        op.ledIndex = 1;
+        pwm.setPin(0, 4095);  // LED 1 (ch0) on
+        op.phase = PH_TEST_LED_ON;
+        op.phaseStart = now;
+      }
+      break;
+    }
+    case PH_TEST_LED_ON: {
+      if (now - op.phaseStart >= 150) {
+        pwm.setPin(op.ledIndex - 1, 0);
+        op.phase = PH_TEST_LED_OFF;
+        op.phaseStart = now;
+      }
+      break;
+    }
+    case PH_TEST_LED_OFF: {
+      if (now - op.phaseStart >= 100) {
+        if (op.ledIndex < 4) {
+          op.ledIndex++;
+          pwm.setPin(op.ledIndex - 1, 4095);
+          op.phase = PH_TEST_LED_ON;
+          op.phaseStart = now;
+        } else {
+          op.phase = PH_NEUTRAL;
+          op.phaseStart = now;
+        }
+      }
+      break;
+    }
+    case PH_CLEAR_OPEN: {
+      if (now - op.phaseStart >= DELAY_PUSH) {
+        op.phase = PH_NEUTRAL;
+        op.phaseStart = now;
+        setAllNeutral();
+      }
+      break;
+    }
+    default:
+      clearOp();  // unknown/unsupported phase — never wedge the machine
+      break;
   }
 }
 
-void handleCommand(char* json) {
+void handleCommand(const char* json) {
   JsonDocument doc;
   DeserializationError err = deserializeJson(doc, json);
   if (err) {
@@ -380,87 +657,108 @@ void handleCommand(char* json) {
     return;
   }
 
+  // Optional numeric "id" — echoed on every reply to this command so the web
+  // app can correlate the response (see replyJson/replyLiteral).
+  g_cmdId = doc["id"] | 0;
+  g_hasCmdId = doc["id"].is<int>();
+
+  // {"cancel": true} — abort the active operation back to neutral at the next
+  // loop() tick. Allowed even while busy.
+  if (doc["cancel"].is<bool>() && doc["cancel"].as<bool>()) {
+    if (op.kind != OP_NONE) cancelRequested = true;
+    replyLiteral("{\"status\":\"cancelled\"}");
+    return;
+  }
+
+  // While an operation is running, most commands would fight the machine (a
+  // servo move mid-route physically yanks a servo). Diagnostics that don't
+  // move the mechanism are still served.
+  if (op.kind != OP_NONE) {
+    if (doc["ping"].is<bool>() && doc["ping"].as<bool>()) {
+      replyLiteral("{\"status\":\"pong\"}");
+      return;
+    }
+    if (doc["led"].is<int>()) {
+      int led = doc["led"].as<int>();
+      if (led < 1 || led > 5) {
+        replyLiteral("{\"error\":\"led must be 1 to 5\"}");
+        return;
+      }
+      bool on = doc["on"] | false;
+      int channel = led <= 4 ? led - 1 : 14;
+      pwm.setPin(channel, on ? 4095 : 0);
+      JsonDocument res;
+      res["status"] = "ok";
+      res["led"] = led;
+      res["on"] = on;
+      replyJson(res);
+      return;
+    }
+    if (doc["readIR"].is<bool>() && doc["readIR"].as<bool>()) {
+      JsonDocument res;
+      res["status"] = "ok";
+      JsonArray ir = res["ir"].to<JsonArray>();
+      for (int m = 1; m <= NUM_MODULES; m++) {
+        ir.add(digitalRead(irPin(m)) == LOW);
+      }
+      res["hopper"] = hopperHasCards();
+      replyJson(res);
+      return;
+    }
+    replyLiteral("{\"error\":\"busy\"}");
+    return;
+  }
+
+  // Re-arm the jam abort for this command (a jam alert during the previous
+  // one must not abort this one before it even starts).
+  jamAbortRequested = false;
+
   // {"test": true} — run a full mechanical test sequence then confirm connection
   if (doc["test"].is<bool>() && doc["test"].as<bool>()) {
-    // Open all bottoms and paddles
-    for (int m = 1; m <= NUM_MODULES; m++) {
-      setServoPosition(getChannel(m, 0), moduleConfig[m - 1].bottomOpen);
-      setServoPosition(getChannel(m, 1), moduleConfig[m - 1].paddleOpen);
-    }
-    delay(DELAY_PUSH);
+    beginTest();
+    return;
+  }
 
-    // Move all pushers left
-    for (int m = 1; m <= NUM_MODULES; m++) {
-      setServoPosition(getChannel(m, 2), moduleConfig[m - 1].pusherLeft);
-    }
-    delay(DELAY_PUSH);
-
-    // Move all pushers right
-    for (int m = 1; m <= NUM_MODULES; m++) {
-      setServoPosition(getChannel(m, 2), moduleConfig[m - 1].pusherRight);
-    }
-    delay(DELAY_PUSH);
-
-    // Reset all servos
-    setAllNeutral();
-    delay(200);
-
-    // Test feeder: spin briefly to verify motor movement (no card expected)
-    setServoPosition(FEEDER_CHANNEL, feederConfig.speed);
-    delay(500);
-    stopFeeder();
-    delay(200);
-
-    // Cycle through LEDs
-    for (int led = 1; led <= 4; led++) {
-      pwm.setPin(led - 1, 4095);
-      delay(150);
-      pwm.setPin(led - 1, 0);
-      delay(100);
-    }
-
-    Serial.println(F("{\"status\":\"test_complete\"}"));
+  // {"ping": true} — liveness check; the web app uses this as a heartbeat
+  if (doc["ping"].is<bool>() && doc["ping"].as<bool>()) {
+    replyLiteral("{\"status\":\"pong\"}");
     return;
   }
 
   // {"neutral": true} — reset all servos
   if (doc["neutral"].is<bool>() && doc["neutral"].as<bool>()) {
     setAllNeutral();
-    Serial.println(F("{\"status\":\"ok\"}"));
+    replyLiteral("{\"status\":\"ok\"}");
     return;
   }
 
   // {"clearDevice": true} — opens every module's bottom trapdoor at once so
   // any card resting in the mechanism drops through to the catch-all area,
   // then returns everything to neutral. Unlike bin 7 routing, this doesn't
-  // call runFeeder() first - it's meant to flush out whatever's physically
+  // run the feeder first - it's meant to flush out whatever's physically
   // stuck regardless of feeder/hopper state.
   if (doc["clearDevice"].is<bool>() && doc["clearDevice"].as<bool>()) {
-    for (int m = 1; m <= NUM_MODULES; m++) {
-      setServoPosition(getChannel(m, 0), moduleConfig[m - 1].bottomOpen);
-    }
-    delay(DELAY_PUSH);
-    setAllNeutral();
-    delay(200);
-    Serial.println(F("{\"status\":\"cleared\"}"));
+    beginClear();
     return;
   }
 
-  // {"led": 1, "on": true} — control LED by position (1 or 2)
+  // {"led": 1, "on": true} — control LED by position (1..4) or the scan light (5)
   if (doc["led"].is<int>()) {
     int led = doc["led"].as<int>();
-    if (led < 1 || led > 4) {
-      Serial.println(F("{\"error\":\"led must be 1 to 4\"}"));
+    if (led < 1 || led > 5) {
+      replyLiteral("{\"error\":\"led must be 1 to 5\"}");
       return;
     }
     bool on = doc["on"] | false;
-    pwm.setPin(led - 1, on ? 4095 : 0);
+    // LEDs 1-4 live on ch0-3; the scan light is LED 5 on spare ch14.
+    int channel = led <= 4 ? led - 1 : 14;
+    pwm.setPin(channel, on ? 4095 : 0);
 
-    Serial.print(F("{\"status\":\"ok\",\"led\":"));
-    Serial.print(led);
-    Serial.print(F(",\"on\":"));
-    Serial.print(on ? F("true") : F("false"));
-    Serial.println(F("}"));
+    JsonDocument res;
+    res["status"] = "ok";
+    res["led"] = led;
+    res["on"] = on;
+    replyJson(res);
     return;
   }
 
@@ -470,12 +768,12 @@ void handleCommand(char* json) {
     const char* servo = doc["servo"];
     int module = doc["module"] | 0;
     if (module < 1 || module > NUM_MODULES) {
-      Serial.println(F("{\"error\":\"module must be 1-3\"}"));
+      replyLiteral("{\"error\":\"module must be 1-3\"}");
       return;
     }
     int offset = getServoOffset(servo);
     if (offset < 0) {
-      Serial.println(F("{\"error\":\"servo must be bottom, paddle, or pusher\"}"));
+      replyLiteral("{\"error\":\"servo must be bottom, paddle, or pusher\"}");
       return;
     }
     int pulse;
@@ -484,18 +782,18 @@ void handleCommand(char* json) {
     } else {
       pulse = getPositionPulse(module, offset, doc["position"] | "neutral");
       if (pulse < 0) {
-        Serial.println(F("{\"error\":\"invalid position\"}"));
+        replyLiteral("{\"error\":\"invalid position\"}");
         return;
       }
     }
     setServoPosition(getChannel(module, offset), pulse);
     delay(200);
 
-    Serial.print(F("{\"status\":\"ok\",\"servo\":\""));
-    Serial.print(servo);
-    Serial.print(F("\",\"module\":"));
-    Serial.print(module);
-    Serial.println(F("}"));
+    JsonDocument res;
+    res["status"] = "ok";
+    res["servo"] = servo;
+    res["module"] = module;
+    replyJson(res);
     return;
   }
 
@@ -504,7 +802,7 @@ void handleCommand(char* json) {
     JsonObject cfg = doc["setConfig"];
     int module = cfg["module"] | 0;
     if (module < 1 || module > NUM_MODULES) {
-      Serial.println(F("{\"error\":\"module must be 1-3\"}"));
+      replyLiteral("{\"error\":\"module must be 1-3\"}");
       return;
     }
     ModuleConfig& c = moduleConfig[module - 1];
@@ -515,35 +813,36 @@ void handleCommand(char* json) {
     c.pusherLeft    = cfg["pusherLeft"]    | c.pusherLeft;
     c.pusherNeutral = cfg["pusherNeutral"] | c.pusherNeutral;
     c.pusherRight   = cfg["pusherRight"]   | c.pusherRight;
+    saveCalibration();  // persist so a reboot keeps the tuned values
 
-    Serial.print(F("{\"status\":\"ok\",\"module\":"));
-    Serial.print(module);
-    Serial.println(F("}"));
+    JsonDocument res;
+    res["status"] = "ok";
+    res["module"] = module;
+    replyJson(res);
     return;
   }
 
   // {"feeder": true} — run feeder until module 1 IR detects a card (or timeout/empty hopper)
   if (doc["feeder"].is<bool>() && doc["feeder"].as<bool>()) {
-    FeedResult result = runFeeder();
-    Serial.print(F("{\"status\":\"ok\",\"detected\":"));
-    Serial.print(result == FEED_DETECTED ? F("true") : F("false"));
-    Serial.print(F(",\"empty\":"));
-    Serial.print(result == FEED_EMPTY ? F("true") : F("false"));
-    Serial.println(F("}"));
+    beginFeed();
     return;
   }
 
   // {"feederValue": N} — set raw PWM (for calibration preview, does not auto-stop)
   if (doc["feederValue"].is<int>()) {
     setServoPosition(FEEDER_CHANNEL, doc["feederValue"].as<int>());
-    Serial.println(F("{\"status\":\"ok\"}"));
+    JsonDocument res;
+    res["status"] = "ok";
+    replyJson(res);
     return;
   }
 
   // {"feederStop": true} — stop feeder immediately
   if (doc["feederStop"].is<bool>() && doc["feederStop"].as<bool>()) {
     stopFeeder();
-    Serial.println(F("{\"status\":\"ok\"}"));
+    JsonDocument res;
+    res["status"] = "ok";
+    replyJson(res);
     return;
   }
 
@@ -556,7 +855,26 @@ void handleCommand(char* json) {
     feederConfig.pauseDuration  = cfg["pauseDuration"]  | feederConfig.pauseDuration;
     feederConfig.settleDuration = cfg["settleDuration"] | feederConfig.settleDuration;
     stopFeeder();
-    Serial.println(F("{\"status\":\"ok\"}"));
+    saveCalibration();  // persist so a reboot keeps the tuned values
+    JsonDocument res;
+    res["status"] = "ok";
+    replyJson(res);
+    return;
+  }
+
+  // {"saveConfig": true} — persist current module + feeder config to EEPROM
+  if (doc["saveConfig"].is<bool>() && doc["saveConfig"].as<bool>()) {
+    saveCalibration();
+    replyLiteral("{\"status\":\"saved\"}");
+    return;
+  }
+
+  // {"resetConfig": true} — restore factory defaults in RAM and EEPROM
+  if (doc["resetConfig"].is<bool>() && doc["resetConfig"].as<bool>()) {
+    setFactoryDefaults();
+    saveCalibration();
+    setAllNeutral();
+    replyLiteral("{\"status\":\"reset\"}");
     return;
   }
 
@@ -567,24 +885,30 @@ void handleCommand(char* json) {
       if (m > 1) Serial.print(',');
       Serial.print(digitalRead(irPin(m)) == LOW ? F("true") : F("false"));  // true = card present
     }
-    Serial.print(F("],\"hopper\":"));
-    Serial.print(hopperHasCards() ? F("true") : F("false"));  // true = cards remain in feeder stack
-    Serial.println(F("}"));
+    res["hopper"] = hopperHasCards();  // true = cards remain in feeder stack
+    replyJson(res);
     return;
   }
 
   // {"bin": N} — route the next card to bin N (1–7)
   if (doc["bin"].is<int>()) {
-    routeCard(doc["bin"].as<int>());
+    int bin = doc["bin"].as<int>();
+    if (bin < 1 || bin > 7) {
+      replyLiteral("{\"error\":\"bin must be 1-7\"}");
+      return;
+    }
+    beginRoute(bin);
     return;
   }
 
-  Serial.println(F("{\"error\":\"unknown command\"}"));
+  replyLiteral("{\"error\":\"unknown command\"}");
 }
 
 void setup() {
   Serial.begin(9600);
   while (!Serial);
+
+  loadCalibration();  // restore tuned config before any servo moves
 
   // IR sensors: active LOW (internal pull-up, sensor pulls LOW when card present)
   pinMode(IR_PIN_MODULE1, INPUT_PULLUP);
@@ -592,33 +916,48 @@ void setup() {
   pinMode(IR_PIN_MODULE3, INPUT_PULLUP);
   pinMode(IR_PIN_HOPPER, INPUT_PULLUP);
 
+  // Interrupt-driven module-1 detection: the feeder stops the instant the beam
+  // is crossed, no polling. Module 2/3 sensors stay polled (they gate routing
+  // waits, where a few ms of latency is fine).
+  attachInterrupt(digitalPinToInterrupt(IR_PIN_MODULE1), onModule1IR, CHANGE);
+
   pwm.begin();
   pwm.setPWMFreq(50);
   delay(10);
   setAllNeutral();
-  Serial.println(F("{\"status\":\"ready\"}"));
+  Serial.println("{\"status\":\"ready\",\"proto\":2}");
+
+  // Report cards already resting at a module gate on boot (e.g. power loss
+  // mid-run) so the operator can clear the device before the first feed.
+  for (int m = 1; m <= NUM_MODULES; m++) {
+    if (digitalRead(irPin(m)) == LOW) {
+      JsonDocument res;
+      res["error"] = "recovered";
+      res["module"] = m;
+      serializeJson(res, Serial);
+      Serial.println();
+    }
+  }
 }
 
 void loop() {
+  // Serial stays responsive during operations: the machine below runs on its
+  // own timers/sensors, so commands are always serviced.
   while (Serial.available()) {
     char c = Serial.read();
     if (c == '\n' || c == '\r') {
-      if (inputOverflowed) {
-        Serial.println(F("{\"error\":\"command too long\"}"));
-        inputOverflowed = false;
-      } else if (inputLen > 0) {
-        inputBuffer[inputLen] = '\0';
+      if (inputBufferLen > 0) {
+        inputBuffer[inputBufferLen] = '\0';
         handleCommand(inputBuffer);
+        inputBufferLen = 0;
       }
-      inputLen = 0;
-    } else if (!inputOverflowed) {
-      if (inputLen < MAX_CMD_LEN) {
-        inputBuffer[inputLen++] = c;
-      } else {
-        inputOverflowed = true;
-        inputLen = 0;
-      }
+    } else if (inputBufferLen < INPUT_BUFFER_MAX) {
+      inputBuffer[inputBufferLen++] = c;
+    } else {
+      inputBufferLen = 0;  // oversized line — discard
+      Serial.println("{\"error\":\"line too long\"}");
     }
   }
-  checkModule1Jam();
+
+  runMachine();
 }


### PR DESCRIPTION
## Why
Feed/route/test/clear were blocking `delay()` sequences: serial froze for
the whole operation, so a jam mid-route was invisible until it timed out,
and the feeder could only pulse (polling IR) instead of running continuously.

## What changed
This is the firmware rework the other two PRs build toward — it includes the
robustness fixes (id-correlated replies, fixed serial buffer, jam watch) and
the config persistence + scan light from the sibling PRs, so this branch is
the complete modern firmware.

- **Non-blocking state machine** — every operation is a phase machine driven
  from `loop()`: `{"cancel":true}` aborts any phase to neutral, jam alerts
  abort immediately, commands arriving mid-run get a clean `{"error":"busy"}`,
  and a whole-operation watchdog replaces per-command deadlines.
- **Interrupt-driven module-1 IR** — the feeder stops the instant the beam is
  crossed (`attachInterrupt`), so the motor runs continuously instead of
  pulse/pause cycling. This is the biggest single throughput win.
- **Scan light on LED 1 (ch0)** for two-frame holo detection.

## Testing
1. Flash; confirm `{"status":"ready"}`.
2. `{"bin":1}` — watch the route run while `{"ping":true}` still answers
   mid-route.
3. Send `{"cancel":true}` mid-route — returns to neutral cleanly.
4. Feed: the feeder runs continuously and stops the moment the card reaches
   module 1's sensor.
5. Hold a card at a gate — jam alert aborts any active operation.
