### PR TITLE
Scope card uniqueness to game and language

### DIFF
--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -53,7 +53,16 @@ export const cardImageVectors = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    unique("card_image_vectors_scryfall_face_idx").on(table.scryfallId),
+    // Card ids are only unique within a game+language: Gundam and One Piece
+    // both print EB01-xxx/STxx-xxx card numbers, and TCGdex Pokemon ids are
+    // identical across languages. A global unique on scryfall_id makes the
+    // second sync silently skip every colliding card (inserts are
+    // onConflictDoNothing), so scope uniqueness to (game_key, lang).
+    unique("cards_game_lang_card_idx").on(
+      table.gameKey,
+      table.lang,
+      table.scryfallId,
+    ),
     crudPolicy({
       role: authenticatedRole,
       read: true,

--- a/packages/server/src/lib/sync-job.ts
+++ b/packages/server/src/lib/sync-job.ts
@@ -1,5 +1,5 @@
 import type { SyncState, SyncStatus } from "@magic-vault/shared";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "../db";
 import { cardImageVectors } from "../db/schema";
 import { resolveGameDataSourceUrl } from "./card-search/resolve";
@@ -152,7 +152,12 @@ async function runSync(source: SyncSource, lang: string): Promise<void> {
   const existing = await db
     .select({ id: cardImageVectors.scryfallId })
     .from(cardImageVectors)
-    .where(eq(cardImageVectors.gameKey, source.gameKey));
+    .where(
+      and(
+        eq(cardImageVectors.gameKey, source.gameKey),
+        eq(cardImageVectors.lang, lang),
+      ),
+    );
   const existingSet = new Set(existing.map((r) => r.id));
 
   addLog(

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -186,8 +186,12 @@ async function syncOneCard(
       embedding,
     })
     .onConflictDoUpdate({
-      target: cardImageVectors.scryfallId,
-      set: { gameKey, lang, name: card.name, setCode: card.setCode, embedding, updatedAt: new Date() },
+      target: [
+        cardImageVectors.gameKey,
+        cardImageVectors.lang,
+        cardImageVectors.scryfallId,
+      ],
+      set: { name: card.name, setCode: card.setCode, embedding, updatedAt: new Date() },
     });
 
   return { success: true, message: `Synced: ${card.name}` };
@@ -229,11 +233,13 @@ router.post(
   async (c) => {
     const scryfallId = c.req.param("scryfallId");
 
-    const existing = await db.query.cardImageVectors.findFirst({
+    // The same card id can exist in multiple games and languages, so
+    // re-vectorize every copy.
+    const existing = await db.query.cardImageVectors.findMany({
       where: (t, { eq }) => eq(t.scryfallId, scryfallId),
       columns: { gameKey: true, lang: true },
     });
-    if (!existing) {
+    if (existing.length === 0) {
       return c.json(
         {
           success: false,
@@ -243,14 +249,15 @@ router.post(
       );
     }
 
-    const result = await syncOneCard(existing.gameKey, scryfallId, existing.lang);
-    if (!result.success) {
-      return c.json({ success: false, message: result.message }, result.status);
+    let message = "";
+    for (const row of existing) {
+      const result = await syncOneCard(row.gameKey, scryfallId, row.lang);
+      if (!result.success) {
+        return c.json({ success: false, message: result.message }, result.status);
+      }
+      message = result.message.replace("Synced:", "Re-vectorized:");
     }
-    return c.json({
-      success: true,
-      message: result.message.replace("Synced:", "Re-vectorized:"),
-    });
+    return c.json({ success: true, message });
   },
 );
 


### PR DESCRIPTION
### Problem

The `cards` table's unique constraint is on `scryfall_id` alone — global across games. But card ids are only unique within a game: Gundam and One Piece both print `EB01-xxx` / `STxx-xxx` card numbers (`EB01-001` exists in both games — verified against both APIs), and TCGdex Pokemon ids are identical across languages. Because sync inserts use `onConflictDoNothing`, whichever game syncs second silently skips every colliding card: it never gets embedded and can never be recognized — the card just routes to the catch-all forever with no error anywhere. This already affects a Pokemon `de`/`ja` sync today, and would block large parts of a future One Piece sync.

### Fix

Scope the unique constraint to `(game_key, lang, scryfall_id)` — matching how the identify query already filters. Schema change only: the repo currently has unrelated drift between `schema.ts` and the drizzle snapshots, so I didn't run `drizzle-kit generate` (it wanted to bundle that drift in). Equivalent SQL:

```sql
ALTER TABLE cards
  DROP CONSTRAINT card_image_vectors_scryfall_face_idx,
  ADD CONSTRAINT cards_game_lang_card_idx UNIQUE (game_key, lang, scryfall_id);
```

The composite constraint is strictly weaker than the current one, so existing data always satisfies it — this can't fail on live data.

Three code changes go with it:

- The sync job's existing-cards skip-list is now scoped to the language being synced — without this, a second-language sync would skip everything the first language enrolled.
- The admin single-card sync upsert targeted `ON CONFLICT (scryfall_id)`; Postgres requires the conflict target to match a unique index exactly, so it now targets `(game_key, lang, scryfall_id)`. Because of this, apply the SQL above together with deploying the code — the conflict target must match whichever constraint is live.
- Revectorize looked up a card by id alone; it now refreshes every copy of an id, since the same id can legitimately exist in more than one game or language.
