### PR TITLE
Add One Piece Card Game

### DIFF
--- a/packages/server/src/lib/card-search/resolve.ts
+++ b/packages/server/src/lib/card-search/resolve.ts
@@ -1,6 +1,7 @@
 import { authQuery, db } from "../../db";
 import { gundamAdapter } from "../gundam/search";
 import { lorcanaAdapter } from "../lorcana/search";
+import { onePieceAdapter } from "../onepiece/search";
 import { pokemonAdapter } from "../pokemon/search";
 import { scryfallAdapter } from "../scryfall/search";
 import { withCache } from "./cache";
@@ -11,6 +12,7 @@ const ADAPTERS_BY_GAME_KEY: Record<string, CardSearchAdapter> = {
   gundam: withCache(gundamAdapter),
   pokemon: withCache(pokemonAdapter),
   lorcana: withCache(lorcanaAdapter),
+  onepiece: withCache(onePieceAdapter),
 };
 
 async function findCollectionGame(jwtClaims: string, collectionGuid: string) {

--- a/packages/server/src/lib/onepiece/search.ts
+++ b/packages/server/src/lib/onepiece/search.ts
@@ -1,0 +1,338 @@
+import type { PlayingCard, Result } from "@magic-vault/shared";
+import { QUERY_MIN_LENGTH } from "@magic-vault/shared";
+import type { CardSearchAdapter } from "../card-search/types";
+
+export const ONE_PIECE_DEFAULT_URL = "https://optcgapi.com/api";
+
+export const ONE_PIECE_HEADERS: Record<string, string> = {
+  "User-Agent": "MagicVault/1.0",
+  Accept: "application/json",
+};
+
+export interface OptcgCard {
+  card_set_id: string;
+  card_name: string;
+  card_image_id: string;
+  card_image: string | null;
+  set_id: string;
+  set_name: string;
+  rarity: string;
+  card_type: string;
+  card_color: string | null;
+  card_cost: string | null;
+  card_power: string | null;
+  counter_amount: number | null;
+  life: string | null;
+  attribute: string | null;
+  sub_types: string | null;
+  card_text: string | null;
+  market_price: number | null;
+  inventory_price: number | null;
+}
+
+const PRINTED_ID_RE = /^(?:OP|ST|EB|PRB)\d{2}-\d{3}$|^P-\d{3}$/;
+
+const ONE_PIECE_COLORS = new Set([
+  "Red",
+  "Green",
+  "Blue",
+  "Purple",
+  "Black",
+  "Yellow",
+]);
+
+// Version ids usually suffix the printed id with an underscore
+// ("OP01-016_p8", "OP13-118_AZWGnsD"), but the API also contains hyphenated
+// typos ("OP09-078-r1") and set-prefixed ids ("EB03_OP09-034_p1"), so extract
+// the first segment shaped like a printed id.
+export function onePiecePrintedId(id: string): string {
+  for (const segment of id.split("_")) {
+    const printed = segment.replace(/-(?:pr|r|p)\d+$/, "");
+    if (PRINTED_ID_RE.test(printed)) return printed;
+  }
+  const idx = id.indexOf("_");
+  return idx > 0 ? id.slice(0, idx) : id;
+}
+
+// The printed id's prefix is the only reliable set code — the API's own
+// set_id field mixes formats ("OP-01" vs "OP01", "OP14-EB04", bare "P").
+export function onePieceSetCode(
+  raw: Pick<OptcgCard, "card_image_id" | "card_set_id" | "set_id">,
+): string {
+  const printed = onePiecePrintedId(raw.card_image_id || raw.card_set_id || "");
+  if (PRINTED_ID_RE.test(printed)) return printed.split("-")[0];
+  return (raw.set_id ?? "").replace("-", "");
+}
+
+export function imageStem(url: string | null | undefined): string {
+  if (!url) return "";
+  const file = url.split("/").pop() ?? "";
+  return file.replace(/\.[a-z]+$/i, "");
+}
+
+// Some printings share a card_image_id with a different image (mostly promo
+// re-prints the API didn't suffix), and one corrupted record's card_set_id
+// names a different card than its image id. Both sides of the app must agree
+// on how those rows are re-keyed, so Search and sync share this: colliding
+// rows are re-keyed by their image filename stem, prefixed with the printed id
+// when the stem alone doesn't carry one — which is exactly the form
+// findVersion resolves back to the row.
+export function dedupeOnePieceRows(
+  rows: OptcgCard[],
+): { rows: { raw: OptcgCard; id: string }[]; dropped: OptcgCard[] } {
+  const seen = new Map<string, { raw: OptcgCard; id: string }>();
+  const dropped: OptcgCard[] = [];
+
+  const stemKey = (collidedId: string, stem: string): string => {
+    if (!stem) return "";
+    if (PRINTED_ID_RE.test(onePiecePrintedId(stem))) return stem;
+    return `${onePiecePrintedId(collidedId)}_${stem}`;
+  };
+
+  for (const raw of rows) {
+    let id = raw.card_image_id || raw.card_set_id;
+    const fromSetId = onePiecePrintedId(raw.card_set_id ?? "");
+    if (
+      PRINTED_ID_RE.test(fromSetId) &&
+      fromSetId !== onePiecePrintedId(id) &&
+      raw.card_image_id
+    ) {
+      // Corrupted merged record: key it under the card_set_id the per-card
+      // endpoints actually group it by, keeping the image id for uniqueness.
+      id = `${fromSetId}_${raw.card_image_id}`;
+    }
+
+    const kept = seen.get(id);
+    if (!kept) {
+      seen.set(id, { raw, id });
+      continue;
+    }
+    if (!raw.card_image || kept.raw.card_image === raw.card_image) {
+      continue; // true re-listing across catalogs
+    }
+
+    const stem = imageStem(raw.card_image);
+    if (stem === id) {
+      // This row's image filename IS the contested id — it is the rightful
+      // owner. Move the previously kept row to its own image stem.
+      const keptStem = stemKey(id, imageStem(kept.raw.card_image));
+      if (keptStem && keptStem !== id && !seen.has(keptStem)) {
+        seen.set(keptStem, { raw: kept.raw, id: keptStem });
+        seen.set(id, { raw, id });
+      } else {
+        dropped.push(raw);
+      }
+      continue;
+    }
+
+    const stemId = stemKey(id, stem);
+    if (stemId && !seen.has(stemId)) {
+      seen.set(stemId, { raw, id: stemId });
+    } else {
+      dropped.push(raw);
+    }
+  }
+
+  return { rows: [...seen.values()], dropped };
+}
+
+export function normalizeOnePieceCard(
+  raw: OptcgCard,
+  id: string = raw.card_image_id || raw.card_set_id,
+): PlayingCard {
+  const cost = raw.card_cost ? Number(raw.card_cost) : NaN;
+  const printedId = onePiecePrintedId(raw.card_image_id || raw.card_set_id);
+
+  return {
+    id,
+    name: raw.card_name,
+    image: raw.card_image
+      ? { small: raw.card_image, normal: raw.card_image }
+      : null,
+    set: onePieceSetCode(raw),
+    setName: raw.set_name,
+    collectorNumber: printedId,
+    rarity: raw.rarity ?? "",
+    typeLine: raw.sub_types
+      ? `${raw.card_type} — ${raw.sub_types}`
+      : raw.card_type,
+    text: raw.card_text || undefined,
+    power: raw.card_power || undefined,
+    colorIdentity: raw.card_color
+      ? raw.card_color.split(" ").filter((c) => ONE_PIECE_COLORS.has(c))
+      : [],
+    price: raw.market_price ?? null,
+    priceFoil: null,
+    cmc: Number.isFinite(cost) ? cost : undefined,
+    raw,
+  };
+}
+
+// Booster set (OPxx/EBxx/PRBxx), starter deck (STxx), and promo (P-xxx) cards
+// live under different API resources, and a promo printing of a set-numbered
+// card only appears under promos — so lookups try the likeliest endpoint
+// first, then the others.
+const CARD_ENDPOINTS = ["sets/card", "decks/card", "promos/card"] as const;
+
+function primaryEndpoint(printedId: string): (typeof CARD_ENDPOINTS)[number] {
+  if (printedId.startsWith("ST")) return "decks/card";
+  if (printedId.startsWith("P-")) return "promos/card";
+  return "sets/card";
+}
+
+export function findVersion(
+  versions: OptcgCard[],
+  id: string,
+): OptcgCard | undefined {
+  const printed = onePiecePrintedId(id);
+  return (
+    versions.find((v) => v.card_image_id === id) ??
+    versions.find((v) => imageStem(v.card_image) === id) ??
+    versions.find((v) => {
+      const stem = imageStem(v.card_image);
+      return !!stem && id === `${printed}_${stem}`;
+    })
+  );
+}
+
+export async function findCardVersion(
+  id: string,
+  baseUrl: string,
+): Promise<{ match: OptcgCard | null; errorStatus?: number }> {
+  const printedId = onePiecePrintedId(id);
+  const primary = primaryEndpoint(printedId);
+  const endpoints = [primary, ...CARD_ENDPOINTS.filter((e) => e !== primary)];
+
+  // The per-card endpoints group rows by card_set_id, which for a few starter
+  // reprints keeps the version suffix ("P-030_r1") — so when the printed id
+  // misses, retry with the raw id as the path key.
+  const keys = id === printedId ? [printedId] : [printedId, id];
+
+  let errorStatus: number | undefined;
+  for (const key of keys) {
+    for (const endpoint of endpoints) {
+      const response = await fetch(
+        `${baseUrl}/${endpoint}/${encodeURIComponent(key)}/`,
+        { headers: ONE_PIECE_HEADERS },
+      );
+      if (!response.ok) {
+        if (response.status !== 404) errorStatus ??= response.status;
+        continue;
+      }
+      const data = (await response.json()) as OptcgCard[];
+      if (!Array.isArray(data)) continue;
+
+      const match =
+        findVersion(data, id) ??
+        (id === printedId || key === id ? data[0] : undefined);
+      if (match) return { match };
+    }
+  }
+
+  return { match: null, errorStatus };
+}
+
+const FILTERED_ENDPOINTS = [
+  "sets/filtered",
+  "decks/filtered",
+  "promos/filtered",
+];
+
+export async function Search(
+  query: string,
+  baseUrl: string = ONE_PIECE_DEFAULT_URL,
+): Promise<Result<PlayingCard[]>> {
+  if (!query || query.trim().length < QUERY_MIN_LENGTH) {
+    return {
+      message: `Your query must be greater than ${QUERY_MIN_LENGTH}`,
+      success: false,
+    };
+  }
+
+  const name = encodeURIComponent(query.trim());
+  const responses = await Promise.all(
+    FILTERED_ENDPOINTS.map((endpoint) =>
+      fetch(`${baseUrl}/${endpoint}/?card_name=${name}`, {
+        headers: ONE_PIECE_HEADERS,
+      }),
+    ),
+  );
+
+  const found: OptcgCard[] = [];
+  let anyOk = false;
+  let errorStatus: number | undefined;
+  for (const response of responses) {
+    if (response.status === 404) {
+      anyOk = true; // the filtered endpoints 404 on no matches
+      continue;
+    }
+    if (!response.ok) {
+      errorStatus ??= response.status;
+      continue;
+    }
+    const data = (await response.json()) as OptcgCard[];
+    if (!Array.isArray(data)) continue;
+    anyOk = true;
+    found.push(...data);
+  }
+
+  if (!anyOk) {
+    return {
+      message: "Failed to fetch from the OPTCG API.",
+      success: false,
+    };
+  }
+
+  // A partial fan-out must not be served (and cached) as a success.
+  if (errorStatus !== undefined) {
+    return {
+      message: `OPTCG API error: ${errorStatus}`,
+      success: false,
+    };
+  }
+
+  if (found.length === 0) {
+    return {
+      message: `No cards were found with the query: ${query}`,
+      success: false,
+    };
+  }
+
+  const { rows } = dedupeOnePieceRows(found);
+
+  return {
+    message: "Cards successfully retrieved.",
+    data: rows.map(({ raw, id }) => normalizeOnePieceCard(raw, id)),
+    success: true,
+  };
+}
+
+export async function SearchById(
+  id: string,
+  baseUrl: string = ONE_PIECE_DEFAULT_URL,
+): Promise<Result<PlayingCard>> {
+  const { match, errorStatus } = await findCardVersion(id, baseUrl);
+
+  if (!match) {
+    return errorStatus
+      ? {
+          success: false,
+          message: `OPTCG API error: ${errorStatus} for card ${id}`,
+        }
+      : { success: false, message: `Card ${id} not found.` };
+  }
+
+  // Keep the requested id: for re-keyed printings the row's own card_image_id
+  // is the collided one, but the requested id is the identity in the app.
+  return {
+    success: true,
+    message: "Successfully fetched card by id.",
+    data: normalizeOnePieceCard(match, id),
+  };
+}
+
+export const onePieceAdapter: CardSearchAdapter = {
+  defaultUrl: ONE_PIECE_DEFAULT_URL,
+  search: Search,
+  searchById: SearchById,
+};

--- a/packages/server/src/lib/onepiece/sync.ts
+++ b/packages/server/src/lib/onepiece/sync.ts
@@ -1,0 +1,78 @@
+import type { SyncSource, SyncSourceCard } from "../card-search/sync-types";
+import {
+  dedupeOnePieceRows,
+  findCardVersion,
+  ONE_PIECE_DEFAULT_URL,
+  ONE_PIECE_HEADERS,
+  onePieceSetCode,
+  type OptcgCard,
+} from "./search";
+
+// Booster sets, starter decks, and promos are separate catalogs. DON!! cards
+// (/allDonCards/) are deliberately not enrolled: they have no printed card id
+// and no per-card endpoint, so a scan match could never resolve back to a
+// card — an unrecognized DON!! simply routes to the catch-all bin.
+const CATALOGS = [
+  { path: "allSetCards", label: "booster sets" },
+  { path: "allSTCards", label: "starter decks" },
+  { path: "allPromos", label: "promos" },
+];
+
+function toSyncCard(raw: OptcgCard, id: string): SyncSourceCard {
+  return {
+    id,
+    name: raw.card_name,
+    setCode: onePieceSetCode(raw),
+    imageUrl: raw.card_image ?? undefined,
+  };
+}
+
+async function fetchCards(
+  baseUrl: string,
+  addLog: (msg: string) => void,
+  _lang?: string,
+  signal?: AbortSignal,
+): Promise<SyncSourceCard[]> {
+  const all: OptcgCard[] = [];
+
+  for (const catalog of CATALOGS) {
+    addLog(`Fetching One Piece ${catalog.label}...`);
+    const res = await fetch(`${baseUrl}/${catalog.path}/`, {
+      headers: ONE_PIECE_HEADERS,
+      signal,
+    });
+    if (!res.ok) {
+      throw new Error(`OPTCG API ${catalog.path} fetch failed: ${res.status}`);
+    }
+
+    const rows = (await res.json()) as OptcgCard[];
+    all.push(...rows);
+    addLog(
+      `Fetched ${catalog.label}: ${rows.length} cards (${all.length} total so far)...`,
+    );
+  }
+
+  const { rows, dropped } = dedupeOnePieceRows(all);
+  if (dropped.length) {
+    addLog(
+      `Skipped ${dropped.length} duplicate listings that could not be re-keyed.`,
+    );
+  }
+
+  return rows.map(({ raw, id }) => toSyncCard(raw, id));
+}
+
+async function fetchOne(id: string, baseUrl: string) {
+  const { match } = await findCardVersion(id, baseUrl);
+  return match ? toSyncCard(match, id) : null;
+}
+
+export const onePieceSyncSource: SyncSource = {
+  gameKey: "onepiece",
+  label: "One Piece Card Game (OPTCG API)",
+  defaultUrl: ONE_PIECE_DEFAULT_URL,
+  fetchHeaders: ONE_PIECE_HEADERS,
+  languages: ["en"],
+  fetchCards,
+  fetchOne,
+};

--- a/packages/server/src/lib/sync-job.ts
+++ b/packages/server/src/lib/sync-job.ts
@@ -7,6 +7,7 @@ import type { SyncSource, SyncSourceCard } from "./card-search/sync-types";
 import { sendDiscordNotification } from "./discord";
 import { gundamSyncSource } from "./gundam/sync";
 import { lorcanaSyncSource } from "./lorcana/sync";
+import { onePieceSyncSource } from "./onepiece/sync";
 import { pokemonSyncSource } from "./pokemon/sync";
 import { scryfallSyncSource } from "./scryfall/sync";
 import { vectorizeImageFromBuffer } from "./vectorize";
@@ -16,6 +17,7 @@ export const SYNC_SOURCES: Record<string, SyncSource> = {
   gundam: gundamSyncSource,
   pokemon: pokemonSyncSource,
   lorcana: lorcanaSyncSource,
+  onepiece: onePieceSyncSource,
 };
 
 type SseWriter = (event: string, data: unknown) => void;

--- a/packages/web/src/features/scanner/components/scanner-debug.tsx
+++ b/packages/web/src/features/scanner/components/scanner-debug.tsx
@@ -225,6 +225,53 @@ const ARIEL_ON_HUMAN_LEGS_ENCHANTED: PlayingCardWithDistance = {
 
 const LORCANA_MOCK_CARDS: PlayingCardWithDistance[] = [ARIEL_ON_HUMAN_LEGS];
 
+// OPTCG API images aren't proxied — plain statics with no hotlink protection,
+// same as the Lorcast mock cards above. The three versions mirror real data:
+// one printed ID (OP01-016) whose printings range from $3.65 to $2,057.
+const NAMI_IMG = "https://optcgapi.com/media/static/Card_Images/OP01-016.jpg";
+
+const NAMI_OP01: PlayingCardWithDistance = {
+  id: "OP01-016",
+  name: "Nami",
+  image: { small: NAMI_IMG, normal: NAMI_IMG },
+  cmc: 1,
+  typeLine: "Character — Straw Hat Crew",
+  text: '[On Play] Look at 5 cards from the top of your deck; reveal up to 1 "Straw Hat Crew" type Character card other than [Nami] and add it to your hand. Then, place the rest at the bottom of your deck in any order.',
+  power: "2000",
+  colorIdentity: ["Red"],
+  set: "OP01",
+  setName: "Romance Dawn",
+  collectorNumber: "OP01-016",
+  rarity: "R",
+  price: 3.65,
+  priceFoil: null,
+  sourceUrl: undefined,
+  distance: 0.03,
+};
+
+const NAMI_PARALLEL_IMG =
+  "https://optcgapi.com/media/static/Card_Images/OP01-016_p1.jpg";
+
+const NAMI_OP01_PARALLEL: PlayingCardWithDistance = {
+  ...NAMI_OP01,
+  id: "OP01-016_p1",
+  name: "Nami (Parallel)",
+  image: { small: NAMI_PARALLEL_IMG, normal: NAMI_PARALLEL_IMG },
+  price: 412.29,
+  distance: 0.05,
+};
+
+const NAMI_OP01_MANGA: PlayingCardWithDistance = {
+  ...NAMI_OP01,
+  id: "OP01-016_p8",
+  name: "Nami (OP01-016) (Manga)",
+  setName: "Premium Booster -The Best-",
+  price: 2057.76,
+  distance: 0.06,
+};
+
+const ONE_PIECE_MOCK_CARDS: PlayingCardWithDistance[] = [NAMI_OP01];
+
 let mockCardIndex = 0;
 
 export function ScannerDebug() {
@@ -238,6 +285,7 @@ export function ScannerDebug() {
   const isGundam = activeCollection?.game?.key === "gundam";
   const isPokemon = activeCollection?.game?.key === "pokemon";
   const isLorcana = activeCollection?.game?.key === "lorcana";
+  const isOnePiece = activeCollection?.game?.key === "onepiece";
 
   const handleSimulateScan = () => {
     const cards = isGundam
@@ -246,7 +294,9 @@ export function ScannerDebug() {
         ? POKEMON_MOCK_CARDS
         : isLorcana
           ? LORCANA_MOCK_CARDS
-          : MOCK_CARDS;
+          : isOnePiece
+            ? ONE_PIECE_MOCK_CARDS
+            : MOCK_CARDS;
     const card = cards[mockCardIndex % cards.length];
     mockCardIndex++;
     addCard(card);
@@ -272,6 +322,10 @@ export function ScannerDebug() {
         ARIEL_ON_HUMAN_LEGS_FOIL,
         ARIEL_ON_HUMAN_LEGS_ENCHANTED,
       ]);
+      return;
+    }
+    if (isOnePiece) {
+      addCard(NAMI_OP01, NAMI_IMG, [NAMI_OP01_PARALLEL, NAMI_OP01_MANGA]);
       return;
     }
     addCard(LIGHTNING_BOLT_M11, FAKE_SCAN_URL, [


### PR DESCRIPTION
Adds the One Piece Card Game under game key `onepiece`, backed by the free, keyless [OPTCG API](https://optcgapi.com) — an adapter + sync source mirroring the Lorcana pair, plus the two registration lines. Design notes, all verified against live API responses and a full captured catalog:

- **Card identity is the per-version `card_image_id`** (`OP01-016` base, `OP01-016_p1` parallel, `OP01-016_p8` manga). One printed ID spans printings from $3.65 to $2,057, each with its own image and market price, so enrolling one embedding per version means a scan match identifies the exact printing — and its price. Same philosophy as MTG's `unique_artwork` sync: recognition keyed by artwork.
- **Name search fans out** to `sets/filtered/`, `decks/filtered/`, and `promos/filtered/` (≈1,300 card names exist only in the deck/promo catalogs).
- **By-id lookups** extract the printed id from the version id and try the likeliest per-card endpoint first (`ST`→decks, `P-`→promos, else sets), then fall back to the others — promo printings of set-numbered cards only appear under promos — and retry with the raw id for the few records whose endpoint group key keeps its version suffix. Non-404 API errors surface as errors, not "not found", and partial search fan-out failures are errors rather than cacheable half-results.
- **Search and sync share one dedupe/re-key policy** so results and enrollment can't drift, and re-keyed ids keep their identity through searchById.
- **The API's rough edges are handled explicitly** (each found in real data): version ids with hyphenated typos (`OP09-078-r1`) or set-code prefixes (`EB03_OP09-034_p1`); `set_id` format soup (`OP-01` vs `OP01` vs `OP14-EB04`) — set codes derive from the printed id instead; ~430 id-colliding printings with different images are re-keyed by image filename (printed-id-prefixed when the filename is a name slug) instead of silently dropped, with contested ids awarded to the printing whose image filename is that id; colors are whitelisted (one record carries a corrupted color value); one corrupted merged record is keyed under the endpoint group that actually returns it.
- **DON!! cards are not enrolled**: no printed id and no per-card endpoint, so a match could never resolve; an unrecognized DON!! routes to the catch-all.
- ~5,100 printings, ~98% with TCGplayer-derived `market_price`. `priceFoil` is `null`: OPTCG has no separate foil price — parallels and alt-arts are their own printings with their own market price, which is what gets enrolled. No image-proxy entry needed: optcgapi.com images are plain statics, used directly like Lorcast images.

Also includes scanner debug cards (`scanner-debug.tsx`), following the Lorcana pattern, so it can be tested locally without a webcam or synced data. Real OP01-016 Nami data: the multi-match simulation presents the base printing against its Parallel and Manga versions — one printed ID spanning $3.65 to $2,057 — which is exactly the version disambiguation One Piece sorting exists for. Images are direct optcgapi.com URLs (no proxy needed, like Lorcast).

Purely additive — two new files, the two registry entries, and the debug mocks; no changes to existing games or shared interfaces, and it stays dormant until an admin adds a game row with key `onepiece`.

Builds on #43 (thanks for the quick merge!): One Piece EB/ST card numbers collide with already-synced Gundam ids under the old global constraint (verified: `EB01-001` exists in both games).

Tested with a fixture server replaying captured API catalogs plus live smoke checks: id routing for every id class, dedupe/re-key round-trips, set-code normalization, null-cost Leaders, dual-color splits, corrupted-record handling, bin-rule evaluation over normalized cards, and a full-catalog resolvability sweep proving all 5,064 enrolled printings resolve with identity preserved — 63 checks (68 with live), all passing. Also running end-to-end on my own instance: full catalog synced and recognized through the scanner.

### Hosted-app setup after merge (admin UI, no code)

1. Games → Add game: key `onepiece`, name `One Piece Card Game`, data source URL `https://optcgapi.com/api`, field definitions below.
2. Run the card sync for `onepiece` (en) — three catalog GETs + ~5,100 images; the API maintainer asks for gentle usage.

<details><summary>Field definitions JSON (tested against the rule engine)</summary>

```json
[
  {
    "field": "rarity",
    "label": "Rarity",
    "type": "enum",
    "path": "rarity",
    "operators": [
      { "value": "in", "label": "is any of" },
      { "value": "not_in", "label": "is none of" },
      { "value": "equals", "label": "equals" },
      { "value": "not_equals", "label": "does not equal" }
    ],
    "options": [
      { "value": "C", "label": "Common" },
      { "value": "UC", "label": "Uncommon" },
      { "value": "R", "label": "Rare" },
      { "value": "SR", "label": "Super Rare" },
      { "value": "SEC", "label": "Secret Rare" },
      { "value": "L", "label": "Leader" },
      { "value": "TR", "label": "Treasure Rare" },
      { "value": "PR", "label": "Promo" }
    ]
  },
  {
    "field": "color",
    "label": "Color",
    "type": "set",
    "path": "colorIdentity",
    "operators": [
      { "value": "contains_any", "label": "contains any of" },
      { "value": "contains_all", "label": "contains all of" },
      { "value": "contains_none", "label": "contains none of" },
      { "value": "equals", "label": "is exactly" }
    ],
    "options": [
      { "value": "Red", "label": "Red" },
      { "value": "Green", "label": "Green" },
      { "value": "Blue", "label": "Blue" },
      { "value": "Purple", "label": "Purple" },
      { "value": "Black", "label": "Black" },
      { "value": "Yellow", "label": "Yellow" }
    ]
  },
  {
    "field": "card_type",
    "label": "Card Type",
    "type": "enum",
    "path": "card_type",
    "operators": [
      { "value": "equals", "label": "equals" },
      { "value": "not_equals", "label": "does not equal" },
      { "value": "in", "label": "is any of" },
      { "value": "not_in", "label": "is none of" }
    ],
    "options": [
      { "value": "Leader", "label": "Leader" },
      { "value": "Character", "label": "Character" },
      { "value": "Event", "label": "Event" },
      { "value": "Stage", "label": "Stage" }
    ]
  },
  {
    "field": "price_usd",
    "label": "Price (USD)",
    "type": "numeric",
    "path": "price",
    "operators": [
      { "value": "gt", "label": "greater than" },
      { "value": "gte", "label": "greater than or equal" },
      { "value": "lt", "label": "less than" },
      { "value": "lte", "label": "less than or equal" },
      { "value": "equals", "label": "equals" }
    ]
  },
  {
    "field": "cost",
    "label": "Cost",
    "type": "numeric",
    "path": "cmc",
    "operators": [
      { "value": "equals", "label": "equals" },
      { "value": "gt", "label": "greater than" },
      { "value": "gte", "label": "greater than or equal" },
      { "value": "lt", "label": "less than" },
      { "value": "lte", "label": "less than or equal" }
    ]
  },
  {
    "field": "power",
    "label": "Power",
    "type": "numeric",
    "path": "card_power",
    "operators": [
      { "value": "equals", "label": "equals" },
      { "value": "gt", "label": "greater than" },
      { "value": "gte", "label": "greater than or equal" },
      { "value": "lt", "label": "less than" },
      { "value": "lte", "label": "less than or equal" }
    ]
  },
  {
    "field": "counter",
    "label": "Counter",
    "type": "numeric",
    "path": "counter_amount",
    "operators": [
      { "value": "equals", "label": "equals" },
      { "value": "gt", "label": "greater than" },
      { "value": "gte", "label": "greater than or equal" },
      { "value": "lt", "label": "less than" },
      { "value": "lte", "label": "less than or equal" }
    ]
  },
  {
    "field": "set",
    "label": "Set Code",
    "type": "string",
    "path": "set",
    "operators": [
      { "value": "equals", "label": "equals" },
      { "value": "not_equals", "label": "does not equal" },
      { "value": "in", "label": "is any of" },
      { "value": "not_in", "label": "is none of" }
    ]
  },
  {
    "field": "attribute",
    "label": "Attribute",
    "type": "string",
    "path": "attribute",
    "operators": [
      { "value": "contains", "label": "contains" },
      { "value": "not_contains", "label": "does not contain" }
    ]
  },
  {
    "field": "types",
    "label": "Types",
    "type": "string",
    "path": "sub_types",
    "operators": [
      { "value": "contains", "label": "contains" },
      { "value": "not_contains", "label": "does not contain" }
    ]
  },
  {
    "field": "name",
    "label": "Name",
    "type": "string",
    "path": "name",
    "operators": [
      { "value": "contains", "label": "contains" },
      { "value": "not_contains", "label": "does not contain" },
      { "value": "equals", "label": "equals" },
      { "value": "not_equals", "label": "does not equal" }
    ]
  },
  {
    "field": "description",
    "label": "Card Text",
    "type": "string",
    "path": "text",
    "operators": [
      { "value": "contains", "label": "contains" },
      { "value": "not_contains", "label": "does not contain" }
    ]
  }
]
```

</details>

Known limitations, by design: one corrupted upstream record (a Buggy manga printing whose row carries another card's stats) displays whatever the API returns — its identity, set, and lookup routing are corrected locally, and it enrolls and resolves. DON!! cards route to the catch-all bin as unrecognized.
